### PR TITLE
Fixup bad boxes + no phantom steps anymore

### DIFF
--- a/kata.dtx
+++ b/kata.dtx
@@ -909,7 +909,6 @@
   \setlength{\lineskip}{6pt}\noindent%
   \setcounter{kata@step}{0}%
   \kata@inkatatrue%
-  \ignorespaces%
 %    \end{macrocode}
 % there is no harm in a single word/pictogram in the last line to turn off the corresponding penalty
 %    \begin{macrocode}
@@ -919,6 +918,7 @@
 % picture outside of the textarea
 %    \begin{macrocode}
   \sloppy
+  \ignorespaces%
 }{%
 %    \end{macrocode}
 % add hidden steps to the last line.

--- a/kata.dtx
+++ b/kata.dtx
@@ -980,7 +980,15 @@
 \NewDocumentEnvironment{kataStep}{O{}+b}{%
   \kata@requirekata{\string\kataStep}%
   \pgfkeys{/kata/step,#1}%
-  \ifkata@step@first\par\nointerlineskip\vfil\else\fi%
+  \ifkata@step@first\par\nointerlineskip\vfil%
+  \else%
+    \pgfmathtruncatemacro{\kata@step@column}{mod(\value{kata@step},\kata@width)}%
+    \ifnum\kata@step@column=\kata@width%
+      \par
+    \else%
+      \hskip 0.0pt plus 1.0fil %
+    \fi%
+  \fi%
   \begin{kata@step}%
     #2
   \end{kata@step}%

--- a/kata.dtx
+++ b/kata.dtx
@@ -915,6 +915,17 @@
   \widowpenalty=0
   \ignorespaces%
 }{%
+%    \end{macrocode}
+% add hidden steps to the last line.
+% This ensures a uniform looking grid of pictograms
+%    \begin{macrocode}
+  \pgfmathtruncatemacro{\kata@missing}{mod(\kata@width - mod(\c@kata@step,\kata@width),\kata@width)}%
+  \ifnum\kata@missing>0
+    \foreach \i in {1,...,\kata@missing} {%
+      \hskip 0pt plus 1fil
+      \rule{\the\kata@phantomstep@width}{\the\kata@phantomsteprule@width}
+    }%
+  \fi%
   \kata@inkatafalse%
 %    \end{macrocode}
 % avoid left-aligning the last line. Instead it should be justified in
@@ -1450,6 +1461,22 @@
   \RequirePackage{memoizable}
 }%
 %    \end{macrocode}
+%
+%
+% \subsection{Internal variables / lengths maybe useful for debugging}
+% \begin{macro}{\kata@phantomsteprule@width}
+%    \begin{macrocode}
+\newdimen\kata@phantomsteprule@width
+\kata@phantomsteprule@width=0pt
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\kata@phantomstep@width}
+%    \begin{macrocode}
+\newdimen\kata@phantomstep@width
+\kata@phantomstep@width=\dimexpr 4.3cm + 0.2em * 2 + 0.4pt * 2\relax
+%    \end{macrocode}
+% \end{macro}
 % \iffalse
 %</package>
 % \fi

--- a/kata.dtx
+++ b/kata.dtx
@@ -975,7 +975,8 @@
 \NewDocumentEnvironment{kataStep}{O{}+b}{%
   \kata@requirekata{\string\kataStep}%
   \pgfkeys{/kata/step,#1}%
-  \ifkata@step@first\par\nointerlineskip\vfil%
+  \ifkata@step@first%
+    \par\nointerlineskip\vfil%
   \else%
     \pgfmathtruncatemacro{\kata@step@column}{mod(\value{kata@step},\kata@width)}%
     \ifnum\kata@step@column=\kata@width%

--- a/kata.dtx
+++ b/kata.dtx
@@ -913,11 +913,6 @@
 % there is no harm in a single word/pictogram in the last line to turn off the corresponding penalty
 %    \begin{macrocode}
   \widowpenalty=0
-%    \end{macrocode}
-% allow large larger spaces between the pictograms if this avoids drawing a
-% picture outside of the textarea
-%    \begin{macrocode}
-  \sloppy
   \ignorespaces%
 }{%
   \kata@inkatafalse%

--- a/kata.dtx
+++ b/kata.dtx
@@ -920,17 +920,6 @@
   \sloppy
   \ignorespaces%
 }{%
-%    \end{macrocode}
-% add hidden steps to the last line.
-% This ensures a uniform looking grid of pictograms
-%    \begin{macrocode}
-  \pgfmathtruncatemacro{\kata@missing}{mod(\kata@width - mod(\c@kata@step,\kata@width),\kata@width)}%
-  \setcounter{kata@step}{0}%
-  \ifnum\kata@missing>0
-    \foreach \i in {1,...,\kata@missing} {%
-      \begin{kataStep}[phantom]\end{kataStep} %
-    }%
-  \fi%
   \kata@inkatafalse%
 %    \end{macrocode}
 % avoid left-aligning the last line. Instead it should be justified in


### PR DESCRIPTION
The issue was when compiling a document, this lead to lots of "bad boxes" reported by LaTeX, despite the output was as expected/desired. The reason for this was I patched too much together over time (thus kinda fighting against LaTeX which only succeeded by e.g. adjusting penalties) instead of solving the issue of spacing properly like LaTeX likes it.

So the core issue seems to be the lacking rubber spaces between the pictures which are needed to obtain the layout I want -> now we explicitly add these spaces/skips (`0pt + 1.0fil`) (idea from https://github.com/atticus-sullivan/kata/pull/11)

(combines/solves the issues raised in https://github.com/atticus-sullivan/kata/issues/9, https://github.com/atticus-sullivan/kata/pull/11 and https://github.com/atticus-sullivan/kata/pull/10)

In addition this also contains the following (partially related) changes:
- [ ] rename `width` to `columns` (more intuitive naming) (idea from https://github.com/atticus-sullivan/kata/pull/10#issuecomment-4202468701)
- [x] don't use full-blown `tikzpicture` for the *phantom*s at the end of the last line. Instead calculate the exact width of a `step` and place a `\rule` with empty height (idea from https://github.com/atticus-sullivan/kata/pull/10#issuecomment-4194865174)

Open for investigation:
- [ ] is setting `\parfillskip` still needed this way?